### PR TITLE
Add ARM64 support for Dev17.

### DIFF
--- a/src/VSIX_Dev17/VSIX_Dev17.csproj
+++ b/src/VSIX_Dev17/VSIX_Dev17.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2124">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/VSIX_Dev17/source.extension.vsixmanifest
+++ b/src/VSIX_Dev17/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)" >
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
     </Dependencies>


### PR DESCRIPTION
Adds an installation target for ARM64 versions of Visual Studio 17.x.

Updates the build tools reference to a version that supports the `arm64` `ProductArchitecture`.